### PR TITLE
Use same bool constructor order as Agda builtin Bool

### DIFF
--- a/test/OddEven.agda
+++ b/test/OddEven.agda
@@ -1,4 +1,4 @@
-data Bool : Set where true false : Bool
+data Bool : Set where false true : Bool
 
 not : Bool -> Bool
 not true  = false

--- a/test/Proj.agda
+++ b/test/Proj.agda
@@ -1,4 +1,4 @@
-data Bool : Set where true false : Bool
+data Bool : Set where false true : Bool
 
 record Pair (A B : Set) : Set where
   constructor _,_


### PR DESCRIPTION
The WebAssembly extraction backend makes assumptions about the constructor order for Bool. So, let's keep the constructor order correct in the tests until we implement constructor reordering.